### PR TITLE
Remove Ruby 2.2 support (unmaintained), add Ruby 2.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,6 @@ steps: &steps
     - run: bundle exec rake run_task_from_env
 
 jobs:
-  ruby-2.2:
-    docker:
-      - image: circleci/ruby:2.2
-    environment:
-      - TASK: spec
-    <<: *steps
-
   ruby-2.3:
     docker:
       - image: circleci/ruby:2.3
@@ -49,16 +42,24 @@ jobs:
       - CODECOV: true
     <<: *steps
 
-  jruby-9.2:
+  ruby-2.6:
     docker:
-      - image: circleci/jruby:9.2
+      - image: circleci/ruby:2.6
+    environment:
+      - TASK: spec
+      - CODECOV: true
+    <<: *steps
+
+  jruby-latest:
+    docker:
+      - image: circleci/jruby:latest
     environment:
       - TASK: spec
     <<: *steps
 
   rubocop:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
     environment:
       - TASK: rubocop
     <<: *steps
@@ -68,9 +69,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby-2.2
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5
-      - jruby-9.2
+      - ruby-2.6
+      - jruby-latest
       - rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 # Specify your gem's dependencies in querystring.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'

--- a/lib/query_string.rb
+++ b/lib/query_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'query_string/version'
 
 # Module with class methods for convertation

--- a/lib/query_string/version.rb
+++ b/lib/query_string/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module QueryString
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.1'
 end

--- a/query_string.gemspec
+++ b/query_string.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'lib/query_string/version'
 
 Gem::Specification.new do |s|
@@ -13,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/query_string_spec.rb
+++ b/spec/query_string_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler.require
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
Switch JRuby to the latest version.

Resolve new offenses from RuboCop.