### PR TITLE
Remove extra `SimpleCov.start`, remove filters of `spec/` for SimpleCov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
       - image: circleci/ruby:2.5
     environment:
       - TASK: spec
-      - CODECOV: true
     <<: *steps
 
   ruby-2.6:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start do
-  add_filter '/spec/'
-end
 SimpleCov.start
 
 if ENV['CODECOV']


### PR DESCRIPTION
Send coverage reports only from Ruby 2.6.